### PR TITLE
[Feat] Add Unlock Notification Sound Volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 mod.db
+.vscode

--- a/ext/server/__init__.lua
+++ b/ext/server/__init__.lua
@@ -121,7 +121,7 @@ function WeapAttachUnlockCheck(player, weaponName, weapKills)
                             print(player.name .. " unlocked " .. unlock.prettyName .. " for " .. weaponUnlocks.prettyName .. " at " .. weapKills .. " kills!")
                             local message = string.format(CONFIG.UnlockNotifications.messages.weapAttachUnlock, weaponUnlocks.prettyName, weapKills, unlock.prettyName)
                             ChatManager:Yell(message, CONFIG.UnlockNotifications.duration, player)
-                            NetEvents:SendTo('PlayUnlockSound', player, CONFIG.UnlockNotifications.soundPaths.weapAttachUnlock)
+                            NetEvents:SendTo('PlayUnlockSound', player, 'weapAttachUnlock')
                             break
                         end
 
@@ -214,7 +214,7 @@ function PlayerLevelUp(player, levelType, level, unlockName)
         if CONFIG.UnlockNotifications.enabled == true then
             local message = string.format(CONFIG.UnlockNotifications.messages.levelUp, levelType, level, unlockName)
             ChatManager:Yell(message, CONFIG.UnlockNotifications.duration, player)
-            NetEvents:SendTo('PlayUnlockSound', player, CONFIG.UnlockNotifications.soundPaths.levelUp)
+            NetEvents:SendTo('PlayUnlockSound', player, 'levelUp')
         end
     end
 end
@@ -258,7 +258,7 @@ function IncreaseVehicleScore(player, playerGuid, vehicleControllableType, score
             if CONFIG.UnlockNotifications.enabled == true then
                 local message = string.format(CONFIG.UnlockNotifications.messages.vehicleUnlock, progCfg.prettyName, playerVicProg.score, unlock.prettyName)
                 ChatManager:Yell(message, CONFIG.UnlockNotifications.duration, player)
-                NetEvents:SendTo('PlayUnlockSound', player, CONFIG.UnlockNotifications.soundPaths.vehicleUnlock)
+                NetEvents:SendTo('PlayUnlockSound', player, 'vehicleUnlock')
             end
             break
         end
@@ -497,6 +497,10 @@ if CONFIG.General.debug then
 
     NetEvents:Subscribe('AddXP', function(player, xp)
         PlayerXPUpdated(player, xp)
+    end)
+
+    NetEvents:Subscribe('AddKillsToWeap', function(player, kills, weapPath)
+        IncreaseWeaponKills(player.guid, weapPath, kills)
     end)
     
 end

--- a/ext/shared/config.lua
+++ b/ext/shared/config.lua
@@ -21,12 +21,21 @@ CONFIG = {
             -- Message must have `%s` for vehicle type name, followed by `%i` for total vehicle score, followed by `%s` for unlock name, in that order
             vehicleUnlock = "[= VEHICLE MILESTONE =]\n%s — %i Vehicle Score\n~ %s Unlocked ~",
         },
-        -- Sound paths to play, based on unlock type
+        -- Sounds to play, based on unlock type
         -- Award sounds: https://github.com/VeniceUnleashed/Venice-EBX/tree/master/Sound/UI/Awards
-        soundPaths = {
-            levelUp = "Sound/UI/Awards/UI_Award_RankUp",
-            weapAttachUnlock = "Sound/UI/Awards/UI_Award_Unlock",
-            vehicleUnlock = "Sound/UI/Awards/UI_Award_RankUp",
+        sounds = {
+            levelUp = {
+                path = "Sound/UI/Awards/UI_Award_RankUp",
+                volumeMult = 2.0, -- Volume multiplier (eg. 2.0 = 200% volume)
+            },
+            weapAttachUnlock = {
+                path = "Sound/UI/Awards/UI_Award_Unlock",
+                volumeMult = 2.0,
+            },
+            vehicleUnlock = {
+                path = "Sound/UI/Awards/UI_Award_RankUp",
+                volumeMult = 2.0,
+            },
         },
     },
 }


### PR DESCRIPTION
- Fixes quiet unlock sounds by adding volume parameter to global config that will be applied to these sounds.
- Fixed `PlayUnlockSound` client debug console command not working.
- Fixed `AddKillsToWeap` client debug console command not working due to missing server-side event listener.
- Added `.vscode` to .gitignore