### PR TITLE
[Feat] Add support for camo unlocks and refactor equipment IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 mod.db
+mod.db.prod
+config.lua.prod
+config.lua.test
 .vscode

--- a/ext/client/LockEquipment.lua
+++ b/ext/client/LockEquipment.lua
@@ -2,42 +2,36 @@ require("__shared/KitVariables")
 local weaponProgConfig = require("__shared/Progression/WeaponProgressionConfig")
 local vehicleProgConfig = require("__shared/Progression/VehicleProgressionConfig")
 
--- Function to remove all the customization options on the selected soldier
-function LockSoldierCustomizationAsset(veniceSoldierAsset, categoryId)
-    local weaponTable = CustomizationTable(veniceSoldierAsset.weaponTable)
-    for i,unlockPart in pairs(weaponTable.unlockParts) do
-        local unlockPart = CustomizationUnlockParts(unlockPart)
-        unlockPart:MakeWritable()
+-- Function to remove all the customization options for a given soldier asset and category ID
+function lockSoldierCustomizationAsset(veniceSoldierAsset, categoryId)
+    local customizationTable
 
-        local partCatId = unlockPart.uiCategorySid
-
-        if partCatId == categoryId then
-            for i = #unlockPart.selectableUnlocks,1,-1 do
-                unlockPart.selectableUnlocks:erase(i)
-            end
-        end
-        
+    -- Get correct CustomizationTable 
+    if categoryId == CUST_UNLOCK_CAT_IDS.specialization then
+        customizationTable = CustomizationTable(veniceSoldierAsset.specializationTable)
+    elseif categoryId == CUST_UNLOCK_CAT_IDS.camo then
+        customizationTable = CustomizationTable(veniceSoldierAsset.visualTable)
+    else
+        customizationTable = CustomizationTable(veniceSoldierAsset.weaponTable)
     end
-end
 
--- Function to remove all the specialization options on the selected soldier
-function lockSoldierSpecializationAsset(veniceSoldierAsset)
-    local specialTable = CustomizationTable(veniceSoldierAsset.specializationTable)
+    -- Loop through UnlockParts until category ID is found 
+    for _, unlockPart in pairs(customizationTable.unlockParts) do
+        local unlockPart = CustomizationUnlockParts(unlockPart)
 
-    if specialTable ~= nil then
-        for _, unlockPart in pairs(specialTable.unlockParts) do
-            local unlockPart = CustomizationUnlockParts(unlockPart)
+        if categoryId == unlockPart.uiCategorySid
+            or categoryId == CUST_UNLOCK_CAT_IDS.camo then -- Camo has special case b/c it has nil ID and only 1 unlock part
             unlockPart:MakeWritable()
-
             for i = #unlockPart.selectableUnlocks,1,-1 do
                 unlockPart.selectableUnlocks:erase(i)
             end
+            break -- Category ID found 
         end
     end
 end
 
 -- Function to remove all the customization options on the selected weapon
-function LockWeaponCustomizationAsset(weaponCustomizationAsset)
+function lockWeaponCustomizationAsset(weaponCustomizationAsset)
     local attachTable = CustomizationTable(weaponCustomizationAsset.customization)
     -- print("{name = " .. weaponCustomizationAsset.name .. "}")
 
@@ -57,7 +51,7 @@ function LockWeaponCustomizationAsset(weaponCustomizationAsset)
 end
 
 -- Function to remove all the customization options on the selected vehicle
-function LockVehicleCustomizationAsset(veniceVehicleCustomizationAsset)
+function lockVehicleCustomizationAsset(veniceVehicleCustomizationAsset)
     for _, unlockPart in pairs(veniceVehicleCustomizationAsset.customization.unlockParts) do
         unlockPart:MakeWritable()
 
@@ -90,21 +84,9 @@ function InitAssetsLock()
             if veniceSoldierAsset ~= nil then
                 veniceSoldierAsset = VeniceSoldierCustomizationAsset(veniceSoldierAsset)
 
-                -- Lock primary weapons
-                LockSoldierCustomizationAsset(veniceSoldierAsset, KIT_PRIMARY_WEAP_ID)
-
-                -- Lock secondary weapons
-                LockSoldierCustomizationAsset(veniceSoldierAsset, KIT_SECONDARY_WEAP_ID)
-
-                -- Lock specializations
-                lockSoldierSpecializationAsset(veniceSoldierAsset)
-
-                -- Lock Soldier Gadget 1
-                LockSoldierCustomizationAsset(veniceSoldierAsset, KIT_SOLDIER_GADGET1_ID)
-
-                -- Lock Soldier Gadget 2
-                LockSoldierCustomizationAsset(veniceSoldierAsset, KIT_SOLDIER_GADGET2_ID)
-
+                for _, categoryId in pairs(CUST_UNLOCK_CAT_IDS) do
+                    lockSoldierCustomizationAsset(veniceSoldierAsset, categoryId)
+                end
             end
         end
     end
@@ -117,7 +99,7 @@ function InitAssetsLock()
         if weaponCustomizationAsset ~= nil then
             weaponCustomizationAsset = VeniceSoldierWeaponCustomizationAsset(weaponCustomizationAsset)
 
-            LockWeaponCustomizationAsset(weaponCustomizationAsset)
+            lockWeaponCustomizationAsset(weaponCustomizationAsset)
         end
     end
 
@@ -129,7 +111,7 @@ function InitAssetsLock()
         if veniceVehicleCustomizationAsset ~= nil then
             veniceVehicleCustomizationAsset = VeniceVehicleCustomizationAsset(veniceVehicleCustomizationAsset)
 
-            LockVehicleCustomizationAsset(veniceVehicleCustomizationAsset)
+            lockVehicleCustomizationAsset(veniceVehicleCustomizationAsset)
         end
     end
 end

--- a/ext/client/UnlockEquipment.lua
+++ b/ext/client/UnlockEquipment.lua
@@ -36,22 +36,19 @@ end
 
 function UnlockEquipment(veniceSoldierAsset, unlockAssetBase, equipmentSlot)
     local customizationTable
-    if equipmentSlot == KIT_SPECIALIZATION_ID then
-        if veniceSoldierAsset.specializationTable == nil then
-            print("specializationTable IS NIL!?")
-            return
-        end
+    
+    -- Get correct CustomizationTable 
+    if equipmentSlot == CUST_UNLOCK_CAT_IDS.specialization then
         customizationTable = CustomizationTable(veniceSoldierAsset.specializationTable)
+    elseif equipmentSlot == CUST_UNLOCK_CAT_IDS.camo then
+        customizationTable = CustomizationTable(veniceSoldierAsset.visualTable)
     else
-        if veniceSoldierAsset.weaponTable == nil then
-            print("weaponTable IS NIL!?")
-            return
-        end
         customizationTable = CustomizationTable(veniceSoldierAsset.weaponTable)
     end
 
     for _, customizationUnlockParts in pairs(customizationTable.unlockParts) do
-        if customizationUnlockParts.uiCategorySid == equipmentSlot then
+        if equipmentSlot == customizationUnlockParts.uiCategorySid
+            or equipmentSlot == CUST_UNLOCK_CAT_IDS.camo then -- Camo has special case b/c it has nil ID and only 1 unlock part
             -- Can later come back to UnlockAssetBase to figure out how to lock or unlock something without removing them from the SoldierAsset
             local foundEquip = false
 

--- a/ext/shared/KitVariables.lua
+++ b/ext/shared/KitVariables.lua
@@ -29,8 +29,11 @@ KITS = {
 -- 'Gameplay/Kits/<KIT>_GM' is for Gun Master gamemode and should not be added
 -- 'Gameplay/Kits/<KIT>_SCV' is for Scavenger gamemode and should not be added
 
-KIT_PRIMARY_WEAP_ID = 'ID_M_SOLDIER_PRIMARY'
-KIT_SECONDARY_WEAP_ID = 'ID_M_SOLDIER_SECONDARY'
-KIT_SPECIALIZATION_ID = 'ID_M_SOLDIER_SPECIALIZATION'
-KIT_SOLDIER_GADGET1_ID = 'ID_M_SOLDIER_GADGET1'
-KIT_SOLDIER_GADGET2_ID = 'ID_M_SOLDIER_GADGET2'
+CUST_UNLOCK_CAT_IDS = {
+    primary = 'ID_M_SOLDIER_PRIMARY',
+    secondary = 'ID_M_SOLDIER_SECONDARY',
+    gadget1 = 'ID_M_SOLDIER_GADGET1',
+    gadget2 = 'ID_M_SOLDIER_GADGET2',
+    specialization = 'ID_M_SOLDIER_SPECIALIZATION',
+    camo = 'CAMO', -- This is not a real ID; it is only referenced internally in this mod
+}

--- a/ext/shared/Progression/GeneralProgressionConfig.lua
+++ b/ext/shared/Progression/GeneralProgressionConfig.lua
@@ -10,33 +10,53 @@ local generalProgression = {
         xpRequired = 0,
         unlocks = {
             {
-        
                 prettyName = 'M9',
                 equipmentPath = 'Weapons/M9/U_M9',
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_SECONDARY',
             },
             {
-                
                 prettyName = 'MP443',
                 equipmentPath = 'Weapons/MP443/U_MP443',
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_SECONDARY',
             },
             {
-                
                 prettyName = 'NONE Specialization',
                 equipmentPath = 'Weapons/Common/NoSpecialization',
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_SPECIALIZATION',
             },
-            -- {
-            --     
-            --     prettyName = 'Default Camo',
-            --     equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO_DEFAULT',
-            --     kits = {'All'},
-            --     slotId = 'CAMO',
-            -- },
+            {
+                prettyName = 'Default Camo', -- Level 1
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO_DEFAULT',
+                kits = {'All'},
+                slotId = 'CAMO',
+            },
+            {
+                prettyName = 'Premium 1 Camo', -- Exclusive Premium bonus
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO_XP2_ABU',
+                kits = {'All'},
+                slotId = 'CAMO',
+            },
+            {
+                prettyName = 'Premium 2 Camo', -- Exclusive Premium bonus
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO_XP2_ATACS',
+                kits = {'All'},
+                slotId = 'CAMO',
+            },
+            {
+                prettyName = 'Premium 3 Camo', -- Exclusive Premium bonus
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO_XP2_DsrtTiger',
+                kits = {'All'},
+                slotId = 'CAMO',
+            },
+            {
+                prettyName = 'Premium 4 Camo', -- Exclusive Premium bonus
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO_XP2_NWU',
+                kits = {'All'},
+                slotId = 'CAMO',
+            },
         }
     },
     {
@@ -58,6 +78,12 @@ local generalProgression = {
                 equipmentPath = 'Persistence/Unlocks/Soldiers/Specializations/SprintBoostL2',
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_SPECIALIZATION',
+            },
+            {
+                prettyName = 'Woodland Pattern Camo', -- Level 3
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO1',
+                kits = {'All'},
+                slotId = 'CAMO',
             },
         }
     },
@@ -92,6 +118,12 @@ local generalProgression = {
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_PRIMARY',
             },
+            {
+                prettyName = 'Ranger Camo', -- Level 6
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO2',
+                kits = {'All'},
+                slotId = 'CAMO',
+            },
         }
     },
     {
@@ -113,6 +145,12 @@ local generalProgression = {
                 equipmentPath = 'Weapons/M9/U_M9_TacticalLight',
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_SECONDARY',
+            },
+            {
+                prettyName = 'Army Green Camo', -- Level 8
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO3',
+                kits = {'All'},
+                slotId = 'CAMO',
             },
         }
     },
@@ -158,6 +196,12 @@ local generalProgression = {
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_PRIMARY',
             },
+            {
+                prettyName = 'Expeditinary Force Camo', -- Level 12
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO4',
+                kits = {'All'},
+                slotId = 'CAMO',
+            },
         }
     },
     {
@@ -190,6 +234,12 @@ local generalProgression = {
                 equipmentPath = 'Persistence/Unlocks/Soldiers/Specializations/GrenadeBoostL2',
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_SPECIALIZATION',
+            },
+            {
+                prettyName = 'Paratrooper Camo', -- Level 15
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO5',
+                kits = {'All'},
+                slotId = 'CAMO',
             },
         }
     },
@@ -224,6 +274,12 @@ local generalProgression = {
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_SECONDARY',
             },
+            {
+                prettyName = 'Navy Blue Camo', -- Level 18
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO6',
+                kits = {'All'},
+                slotId = 'CAMO',
+            },
         }
     },
     {
@@ -245,6 +301,12 @@ local generalProgression = {
                 equipmentPath = 'Weapons/MP443/U_MP443_Silenced',
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_SECONDARY',
+            },
+            {
+                prettyName = 'Jungle Pattern Camo', -- Level 20
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO7',
+                kits = {'All'},
+                slotId = 'CAMO',
             },
         }
     },
@@ -290,6 +352,12 @@ local generalProgression = {
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_PRIMARY',
             },
+            {
+                prettyName = 'Desert Khaki Camo', -- Level 24
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO8',
+                kits = {'All'},
+                slotId = 'CAMO',
+            },
         }
     },
     {
@@ -322,6 +390,12 @@ local generalProgression = {
                 equipmentPath = 'Persistence/Unlocks/Soldiers/Specializations/SuppressionResistL2',
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_SPECIALIZATION',
+            },
+            {
+                prettyName = 'Urban Pattern Camo', -- Level 27
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO9',
+                kits = {'All'},
+                slotId = 'CAMO',
             },
         }
     },
@@ -455,6 +529,12 @@ local generalProgression = {
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_SECONDARY',
             },
+            {
+                prettyName = 'Veteran Kit Camo', -- Level 39
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO10',
+                kits = {'All'},
+                slotId = 'CAMO',
+            },
         }
     },
     {
@@ -487,6 +567,12 @@ local generalProgression = {
                 equipmentPath = 'Weapons/ASVal/U_ASVal',
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_PRIMARY',
+            },
+            {
+                prettyName = 'Spec Ops Black Camo', -- Level 42
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO11',
+                kits = {'All'},
+                slotId = 'CAMO',
             },
         }
     },
@@ -521,6 +607,12 @@ local generalProgression = {
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_PRIMARY',
             },
+            {
+                prettyName = 'SPECACT Camo', -- Pre-order bonus & Purchasable content
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO_SPECACT',
+                kits = {'All'},
+                slotId = 'CAMO',
+            },
         }
     },
     {
@@ -553,6 +645,12 @@ local generalProgression = {
                 equipmentPath = 'Weapons/XP4_Crossbow_Prototype/U_Crossbow_Scoped_RifleScope',
                 kits = {'All'},
                 slotId = 'ID_M_SOLDIER_GADGET1',
+            },
+            {
+                prettyName = 'Dr. Pepper Camo', -- Dr. Pepper promotion & Purchasable content
+                equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO_DrPepper',
+                kits = {'All'},
+                slotId = 'CAMO',
             },
         }
     },


### PR DESCRIPTION
- Introduces soldier camo unlocks to the general progression config and updates related logic to handle camos as a new customization category.
- Refactors equipment slot IDs into a `CUST_UNLOCK_CAT_IDS` table for consistency and maintainability.
- Refactors lock/unlock functions to use the new category IDs and handle camo as a special case.
- Updates .gitignore to include production and test config/database files.