### PR TITLE
[v3.0.2] Hotfix for Camos not working on XP4 maps

### DIFF
--- a/ext/client/UnlockEquipment.lua
+++ b/ext/client/UnlockEquipment.lua
@@ -2,7 +2,7 @@ require("__shared/KitVariables")
 
 function ApplyUnlock(equipmentPath, equipmentSlot, kitName)
     local unlockAssetBase = ResourceManager:SearchForDataContainer(equipmentPath)
-    -- Handle XP4 maps having different equipment paths
+    -- Handle XP4 maps having different equipment paths for soldier camos
     if unlockAssetBase == nil and equipmentSlot == CUST_UNLOCK_CAT_IDS.camo then
         -- Default camo is the only one that doesn't end in '_XP4'
         if equipmentPath:match("_DEFAULT$") then

--- a/ext/client/UnlockEquipment.lua
+++ b/ext/client/UnlockEquipment.lua
@@ -2,6 +2,17 @@ require("__shared/KitVariables")
 
 function ApplyUnlock(equipmentPath, equipmentSlot, kitName)
     local unlockAssetBase = ResourceManager:SearchForDataContainer(equipmentPath)
+    -- Handle XP4 maps having different equipment paths
+    if unlockAssetBase == nil and equipmentSlot == CUST_UNLOCK_CAT_IDS.camo then
+        -- Default camo is the only one that doesn't end in '_XP4'
+        if equipmentPath:match("_DEFAULT$") then
+            equipmentPath = equipmentPath:gsub("_DEFAULT$", "_XP4_DEFAULT")
+        else
+            equipmentPath = equipmentPath .. "_XP4"
+        end
+        unlockAssetBase = ResourceManager:SearchForDataContainer(equipmentPath)
+    end
+    -- Final check if resource was found
     if unlockAssetBase == nil then
         print("CANNOT FIND UNLOCK equipmentPath: " .. equipmentPath)
         return

--- a/ext/shared/Progression/GeneralProgressionConfig.lua
+++ b/ext/shared/Progression/GeneralProgressionConfig.lua
@@ -29,6 +29,7 @@ local generalProgression = {
             },
             {
                 prettyName = 'Default Camo', -- Level 1
+                -- Do not use 'XP4' paths for camos; they will be automatically converted when needed
                 equipmentPath = 'UI/Art/Persistence/Camo/U_CAMO_DEFAULT',
                 kits = {'All'},
                 slotId = 'CAMO',

--- a/ext/shared/Version.lua
+++ b/ext/shared/Version.lua
@@ -1,5 +1,5 @@
 VERSION = {
     Major = 3,
     Minor = 0,
-    Patch = 1
+    Patch = 2
 }

--- a/mod.json
+++ b/mod.json
@@ -5,7 +5,7 @@
         "Red-Thirten"
     ],
     "Description": "A mod that integrates progression into Venice Unleashed",
-    "Version": "3.0.1",
+    "Version": "3.0.2",
     "URL": "https://github.com/thysw95/vu-progression",
     "HasVeniceEXT": true,
     "Dependencies": {


### PR DESCRIPTION
XP4 maps have different equipment paths for camos, but they are very similar to the regular paths. This fix programmatically adjusts the regular paths in the General Progression Config to be XP4 paths if the regular path can't be loaded (ie. when on a XP4 map).