### PR TITLE
[v3.0.3] Hotfix BetterIngameChat compatibility & add update checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The mod is written in [VEXT (VeniceEXT)](https://docs.veniceunleashed.net/vext/)
 - **Contributors**:
   - [Red-Thirten](https://github.com/redthirten)
 - Additional thanks to [Doc-ice](https://github.com/Doc-ice) for keeping the mod going on the side!
+- Additional thanks to [Joe91](https://github.com/Joe91) for update checking code snippets.
 
 Special thanks to the [Venice Unleashed](https://veniceunleashed.net/) team and community.
 

--- a/ext/server/UpdateCheck.lua
+++ b/ext/server/UpdateCheck.lua
@@ -1,0 +1,89 @@
+require("__shared/Version")
+local ParseOffset = require("lib/iso8601")
+
+-- Prints the update check result to console
+-- @author Joe91 <https://github.com/Joe91>
+---@param p_Result integer
+---@param p_UpdateUrl string|nil
+---@param p_RemoteVersion string|nil
+---@param p_RemoteTimestamp string|nil
+local function UpdateFinished(p_Result, p_UpdateUrl, p_RemoteVersion, p_RemoteTimestamp)
+	-- Check if the update was successful.
+	if p_Result < 0 then
+		print('[Update Check] Failed to check for an update.')
+		return
+	end
+
+	-- Check if there is not an update available and that we are running the latest version.
+	if p_Result == 0 then
+		print('[Update Check] You are running the latest version.')
+		return
+	end
+
+	-- Mod is outdated
+	if p_Result == 1 then
+		if p_RemoteTimestamp ~= nil then
+			print('[ + ] A new version for vu-progression was released on ' ..
+				os.date('%d-%m-%Y %H:%M', ParseOffset(p_RemoteTimestamp)) .. '!')
+		else
+			print('[ + ] A new version for vu-progression is available!')
+		end
+
+		print('[ + ] Upgrade to ' .. p_RemoteVersion)
+		print('[ + ] Download: ' .. p_UpdateUrl)
+	end
+end
+
+-- Compares external version string against mod's VERSION dictionary
+---@param p_ExternalVersion string|nil
+local function CompareVersion(p_ExternalVersion)
+	local major, minor, patch = p_ExternalVersion:match("^v(%d+)%.(%d+)%.(%d+)$")
+
+	local d_ExtVer = {
+		Major = tonumber(major),
+		Minor = tonumber(minor),
+		Patch = tonumber(patch)
+	}
+
+	-- Check for outdated mod
+	if d_ExtVer.Major > VERSION.Major
+		or d_ExtVer.Minor > VERSION.Minor
+		or d_ExtVer.Patch > VERSION.Patch
+	then
+		return 1
+	else
+		return 0
+	end
+end
+
+-- Callback for updateCheck async request.
+---@param httpRequest HttpResponse|nil
+local function updateCheckCB(httpRequest)
+	if httpRequest == nil then
+		UpdateFinished(-1, nil, nil, nil)
+		return
+	end
+	-- Parse JSON.
+	local s_EndpointJSON = json.decode(httpRequest.body)
+
+	if s_EndpointJSON == nil or s_EndpointJSON['tag_name'] == nil then
+		UpdateFinished(-1, nil, nil, nil)
+		return
+	end
+
+	local s_Result = CompareVersion(s_EndpointJSON['tag_name'])
+	
+	UpdateFinished(
+		s_Result,
+		s_EndpointJSON['html_url'],
+		s_EndpointJSON['tag_name'],
+		s_EndpointJSON['published_at']
+	)
+end
+
+-- Async check for newer updates.
+local function UpdateCheck()
+	Net:GetHTTPAsync(VERSION.GithubApiUrl, updateCheckCB)
+end
+
+return UpdateCheck

--- a/ext/server/__init__.lua
+++ b/ext/server/__init__.lua
@@ -1,7 +1,8 @@
 require("__shared/config")
 require("__shared/Version")
 require("__shared/KitVariables")
-local StorageManager = require('StorageManager/StorageManager')
+local UpdateCheck = require("UpdateCheck")
+local StorageManager = require("StorageManager/StorageManager")
 
 
 local PROG_CONFIGS = {
@@ -412,6 +413,12 @@ end)
 
 NetEvents:Subscribe('AddNewPlayerForStats', function(player)
     addPlayerToRankUpList(player)
+end)
+
+Events:Subscribe('Engine:Init', function()
+    if CONFIG.General.updateCheck then
+        UpdateCheck()
+    end
 end)
 
 Events:Subscribe('Extension:Loaded', function()

--- a/ext/server/__init__.lua
+++ b/ext/server/__init__.lua
@@ -438,6 +438,10 @@ Events:Subscribe('Server:RoundOver', function(roundTime, winningTeam)
 end)
 
 Events:Subscribe('Player:Chat', ChatCommand)
+-- BetterIngameChat compatibility
+NetEvents:Subscribe('ClientServer_Chat', function(p_Player, p_Target, p_Message, p_TargetName)
+    ChatCommand(p_Player, nil, p_Message)
+end)
 
 -- DEBUG
 if CONFIG.General.debug then

--- a/ext/server/lib/iso8601.lua
+++ b/ext/server/lib/iso8601.lua
@@ -1,0 +1,19 @@
+-- Parse ISO 8601 timestamp (https://stackoverflow.com/questions/7911322/lua-iso-8601-datetime-parsing-pattern).
+-- @author Firjen <https://github.com/Firjens>
+local function ParseOffset(p_String)
+	local s_Pattern = "(%d+)%-(%d+)%-(%d+)%a(%d+)%:(%d+)%:([%d%.]+)([Z%+%-])(%d?%d?)%:?(%d?%d?)"
+	local s_Year, s_Month, s_Day, s_Hour, s_Minute, s_Seconds, s_Offsetsign, s_Offsethour, s_Offsetmin = p_String:match(s_Pattern)
+	local s_Timestamp = os.time { year = s_Year, month = s_Month,
+		day = s_Day, hour = s_Hour, min = s_Minute, sec = s_Seconds }
+	local s_Offset = 0
+
+	if s_Offsetsign ~= 'Z' then
+		s_Offset = tonumber(s_Offsethour) * 60 + tonumber(s_Offsetmin)
+
+		if s_Offset == "-" then s_Offset = s_Offset * -1 end
+	end
+
+	return s_Timestamp + s_Offset
+end
+
+return ParseOffset

--- a/ext/shared/Version.lua
+++ b/ext/shared/Version.lua
@@ -1,5 +1,6 @@
 VERSION = {
     Major = 3,
     Minor = 0,
-    Patch = 2
+    Patch = 2,
+    GithubApiUrl = 'https://api.github.com/repos/thysw95/vu-progression/releases/latest?per_page=1'
 }

--- a/ext/shared/Version.lua
+++ b/ext/shared/Version.lua
@@ -1,6 +1,6 @@
 VERSION = {
     Major = 3,
     Minor = 0,
-    Patch = 2,
+    Patch = 3,
     GithubApiUrl = 'https://api.github.com/repos/thysw95/vu-progression/releases/latest?per_page=1'
 }

--- a/ext/shared/config.lua
+++ b/ext/shared/config.lua
@@ -4,6 +4,9 @@
 
 CONFIG = {
     General = {
+        -- Enable checking for updates on start
+        -- (Receive a notification in the server console if an update is available)
+        updateCheck = true,
         -- Multiplier for how quickly you gain experience in game
         -- (Does not apply if Global Progression is enabled)
         xpMultiplier = 1,

--- a/mod.json
+++ b/mod.json
@@ -5,7 +5,7 @@
         "Red-Thirten"
     ],
     "Description": "A mod that integrates progression into Venice Unleashed",
-    "Version": "3.0.2",
+    "Version": "3.0.3",
     "URL": "https://github.com/thysw95/vu-progression",
     "HasVeniceEXT": true,
     "Dependencies": {


### PR DESCRIPTION
- 59fe743 [Bugfix] Add [BetterIngameChat](https://github.com/FlashHit/BetterIngameChat) compatibility
  - Adds compatibility for the [BetterIngameChat](https://github.com/FlashHit/BetterIngameChat) mod by fixing an issue where progression chat commands were not received when running this mod.
- d299c53 [Feat] Add update checking
  - Adds update checking feature that (if enabled in the config) will compare the mod's version against the latest GitHub version. It then prints its result to the server console on startup.
- 80a8889 [Chore] Bump version to 3.0.3