### PR TITLE
Made starting pistols faction-specific, like in base game

### DIFF
--- a/ext/shared/Progression/GeneralProgressionConfig.lua
+++ b/ext/shared/Progression/GeneralProgressionConfig.lua
@@ -12,13 +12,31 @@ local generalProgression = {
             {
                 prettyName = 'M9',
                 equipmentPath = 'Weapons/M9/U_M9',
-                kits = {'All'},
+                kits = {
+                    'Gameplay/Kits/USAssault',
+                    'Gameplay/Kits/USAssault_XP4',
+                    'Gameplay/Kits/USEngineer',
+                    'Gameplay/Kits/USEngineer_XP4',
+                    'Gameplay/Kits/USSupport',
+                    'Gameplay/Kits/USSupport_XP4',
+                    'Gameplay/Kits/USRecon',
+                    'Gameplay/Kits/USRecon_XP4',
+                },
                 slotId = 'ID_M_SOLDIER_SECONDARY',
             },
             {
                 prettyName = 'MP443',
                 equipmentPath = 'Weapons/MP443/U_MP443',
-                kits = {'All'},
+                kits = {
+                    'Gameplay/Kits/RUAssault',
+                    'Gameplay/Kits/RUAssault_XP4',
+                    'Gameplay/Kits/RUEngineer',
+                    'Gameplay/Kits/RUEngineer_XP4',
+                    'Gameplay/Kits/RUSupport',
+                    'Gameplay/Kits/RUSupport_XP4',
+                    'Gameplay/Kits/RURecon',
+                    'Gameplay/Kits/RURecon_XP4',
+                },
                 slotId = 'ID_M_SOLDIER_SECONDARY',
             },
             {


### PR DESCRIPTION
To use a faction's starting pistol as the opposite faction, 100 kills must be made with the weapon. I don't think such unlock progression can be implemented yet in the mod, so with these changes, the starting weapon won't be usable by the opposite faction. Still, I think this is better because it retains the original flavor of the game since a lot of players of the original game probably unlock the M9/MP443 for the opposite faction late in the game or never because 100 kills with the pistol is a high requirement.